### PR TITLE
Discordbot cog

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
         args: [ --remove ]
       - id: detect-private-key
       - id: check-added-large-files
+        args: [ --maxkb=1000 ]
       - id: check-ast  # Is it valid Python?
       - id: debug-statements  # Check for debugger imports and py37+ breakpoint() calls
       - id: check-merge-conflict
@@ -41,13 +42,13 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: django-upgrade
-        args: [ --target-version, "3.2" ]
+        args: [ --target-version=3.2 ]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
@@ -71,12 +72,14 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+        args: [ --target-version=py37 ]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:
       - id: blacken-docs
         additional_dependencies: [ black==22.3.0 ]
+        args: [ --target-version=py37 ]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+### Added
+
+- Cog for `allianceauth-discordbot` to implement the `/time` command for Discord
+  - **Advice:** Please make sure `aadiscordbot` is listed _before_ `timezones` in
+    `INSTALLED_APPS` in your `local.py` to prevent an error from spawning in your
+    log file. It will still work, but the error is annoying and might cause
+    unnecessary questions in the Alliance Auth support Discord.
+
 ### Changed
 
 - JS modernized (Part 2)

--- a/timezones/aadiscordbot/cogs/time.py
+++ b/timezones/aadiscordbot/cogs/time.py
@@ -1,0 +1,132 @@
+"""
+"Time" cog for discordbot - https://github.com/pvyParts/allianceauth-discordbot
+"""
+
+# Standard Library
+from datetime import datetime
+
+# Third Party
+import pytz
+from aadiscordbot.app_settings import get_site_url, timezones_active
+from discord.colour import Color
+from discord.embeds import Embed
+from discord.ext import commands
+
+# Django
+from django.conf import settings
+from django.urls import reverse
+
+# AA Time Zones
+from timezones.constants import AA_TIMEZONE_DEFAULT_PANELS
+from timezones.models import Timezones
+
+
+class Time(commands.Cog):
+    """
+    A series of Time tools
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    def show_timezones(self):
+        """
+        Create and format the embed for Discord
+        """
+
+        fmt_utc = "%H:%M:%S (UTC)\n%A %d. %b %Y"
+        fmt = "%H:%M:%S (UTC %z)\n%A %d. %b %Y"
+        url = None
+
+        embed = Embed(title="Time")
+        embed.colour = Color.green()
+
+        embed.add_field(
+            name="EVE Time",
+            value=datetime.utcnow().strftime(fmt_utc),
+            inline=False,
+        )
+
+        if timezones_active():
+            url = get_site_url() + reverse("timezones:index")
+            configured_timezones = (
+                Timezones.objects.select_related("timezone")
+                .filter(is_enabled=True)
+                .order_by("panel_name")
+            )
+
+            # Get configured timezones from module setting
+            if configured_timezones.count() > 0:
+                for configured_timezone in configured_timezones:
+                    embed.add_field(
+                        name=configured_timezone.panel_name,
+                        value=(
+                            datetime.utcnow()
+                            .astimezone(
+                                pytz.timezone(
+                                    configured_timezone.timezone.timezone_name
+                                )
+                            )
+                            .strftime(fmt)
+                        ),
+                        inline=True,
+                    )
+
+            # get default timezones from module
+            else:
+                configured_timezones = AA_TIMEZONE_DEFAULT_PANELS
+
+                for configured_timezone in configured_timezones:
+                    embed.add_field(
+                        name=configured_timezone["panel_name"],
+                        value=(
+                            datetime.utcnow()
+                            .astimezone(
+                                pytz.timezone(
+                                    configured_timezone["timezone"]["timezone_name"]
+                                )
+                            )
+                            .strftime(fmt)
+                        ),
+                        inline=True,
+                    )
+
+        # add url to the timezones module
+        if url is not None:
+            embed.add_field(
+                name="Timezones Conversion",
+                value=url,
+                inline=False,
+            )
+
+        return embed
+
+    @commands.command(pass_context=True)
+    async def time(self, ctx):
+        """
+        Returns the Eve time and the current time in various time zones
+        """
+
+        return await ctx.send(embed=self.show_timezones())
+
+    @commands.slash_command(name="time", guild_ids=[int(settings.DISCORD_GUILD_ID)])
+    async def time_slash(self, ctx):
+        """
+        Returns the Eve time and the current time in various time zones
+        """
+
+        return await ctx.respond(embed=self.show_timezones())
+
+
+def setup(bot):
+    """
+    Setup the cog
+    :param bot:
+    """
+
+    # Unload the `time` extemsion from `aadiscordbot`, so we can load our own
+    if bot.get_cog("Time") is not None:
+        bot.unload_extension("aadiscordbot.cogs.time")
+
+    # Load our `time` extension
+    bot.add_cog(Time(bot))

--- a/timezones/auth_hooks.py
+++ b/timezones/auth_hooks.py
@@ -54,3 +54,14 @@ def register_urls():
     :return:
     """
     return UrlHook(urls, "timezones", r"^timezones/")
+
+
+@hooks.register("discord_cogs_hook")
+def register_cogs():
+    """
+    Registering our discord cog
+    :return:
+    :rtype:
+    """
+
+    return ["timezones.aadiscordbot.cogs.time"]


### PR DESCRIPTION
## Description

### Added

- Cog for `allianceauth-discordbot` to implement the `/time` command for Discord
  - **Advice:** Please make sure `aadiscordbot` is listed _before_ `timezones` in
    `INSTALLED_APPS` in your `local.py` to prevent an error from spawning in your
    log file. It will still work, but the error is annoying and might cause
    unnecessary questions in the Alliance Auth support Discord.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
