### PR TITLE
[FIX] Translatable strings in dropdown in admin backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Capitalization for translatable strings
+- Translatable strings in dropdown in admin backend
 
 ### Changed
 

--- a/timezones/admin.py
+++ b/timezones/admin.py
@@ -32,7 +32,7 @@ class TimezonesAdmin(admin.ModelAdmin):
 
     actions = ("mark_as_active", "mark_as_inactive")
 
-    @admin.action(description=_("Activate selected timezone(s)"))
+    @admin.action(description=_("Activate selected timezones"))
     def mark_as_active(self, request, queryset):
         """
         Mark timezone as active
@@ -72,7 +72,7 @@ class TimezonesAdmin(admin.ModelAdmin):
                 ).format(notifications_count=notifications_count),
             )
 
-    @admin.action(description="Deactivate selected time zone(s)")
+    @admin.action(description=_("Deactivate selected timezones"))
     def mark_as_inactive(self, request, queryset):
         """
         Mark timezone as inactive

--- a/timezones/locale/de/LC_MESSAGES/django.po
+++ b/timezones/locale/de/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:12+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: German <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -36,7 +36,9 @@ msgid "Time zone"
 msgstr "Zeitzone"
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+#, fuzzy
+#| msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr "Ausgewählte Zeitzone"
 
 #: admin.py:59
@@ -52,6 +54,12 @@ msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] "{notifications_count} Zeitzone aktiviert"
 msgstr[1] "{notifications_count} Zeitzonen aktiviert"
+
+#: admin.py:75
+#, fuzzy
+#| msgid "Activate selected timezone(s)"
+msgid "Deactivate selected timezones"
+msgstr "Ausgewählte Zeitzone"
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/django.pot
+++ b/timezones/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,7 +32,7 @@ msgid "Time zone"
 msgstr ""
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr ""
 
 #: admin.py:59
@@ -48,6 +48,10 @@ msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
 msgstr[1] ""
+
+#: admin.py:75
+msgid "Deactivate selected timezones"
+msgstr ""
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/es/LC_MESSAGES/django.po
+++ b/timezones/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: Spanish <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -37,7 +37,7 @@ msgstr "Zona horaria"
 #: admin.py:35
 #, fuzzy
 #| msgid "Selected timezone"
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr "Zona horaria seleccionada"
 
 #: admin.py:59
@@ -53,6 +53,12 @@ msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
 msgstr[1] ""
+
+#: admin.py:75
+#, fuzzy
+#| msgid "Selected timezone"
+msgid "Deactivate selected timezones"
+msgstr "Zona horaria seleccionada"
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/fr_FR/LC_MESSAGES/django.po
+++ b/timezones/locale/fr_FR/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: French <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -32,7 +32,7 @@ msgid "Time zone"
 msgstr ""
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr ""
 
 #: admin.py:59
@@ -48,6 +48,10 @@ msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
 msgstr[1] ""
+
+#: admin.py:75
+msgid "Deactivate selected timezones"
+msgstr ""
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/it_IT/LC_MESSAGES/django.po
+++ b/timezones/locale/it_IT/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: Italian <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -32,7 +32,7 @@ msgid "Time zone"
 msgstr ""
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr ""
 
 #: admin.py:59
@@ -48,6 +48,10 @@ msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
 msgstr[1] ""
+
+#: admin.py:75
+msgid "Deactivate selected timezones"
+msgstr ""
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/ja/LC_MESSAGES/django.po
+++ b/timezones/locale/ja/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Japanese <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -32,7 +32,7 @@ msgid "Time zone"
 msgstr ""
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr ""
 
 #: admin.py:59
@@ -46,6 +46,10 @@ msgstr[0] ""
 msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
+
+#: admin.py:75
+msgid "Deactivate selected timezones"
+msgstr ""
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/ko_KR/LC_MESSAGES/django.po
+++ b/timezones/locale/ko_KR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -37,7 +37,7 @@ msgstr "시간대"
 #: admin.py:35
 #, fuzzy
 #| msgid "Selected timezone"
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr "선택된 시간대"
 
 #: admin.py:59
@@ -51,6 +51,12 @@ msgstr[0] ""
 msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
+
+#: admin.py:75
+#, fuzzy
+#| msgid "Selected timezone"
+msgid "Deactivate selected timezones"
+msgstr "선택된 시간대"
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/ru/LC_MESSAGES/django.po
+++ b/timezones/locale/ru/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: Russian <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -42,7 +42,7 @@ msgstr "Часовой пояс"
 #: admin.py:35
 #, fuzzy
 #| msgid "Selected timezone"
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr "Выбранный часовой пояс"
 
 #: admin.py:59
@@ -62,6 +62,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
+
+#: admin.py:75
+#, fuzzy
+#| msgid "Selected timezone"
+msgid "Deactivate selected timezones"
+msgstr "Выбранный часовой пояс"
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/uk/LC_MESSAGES/django.po
+++ b/timezones/locale/uk/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: Ukrainian <https://weblate.ppfeufer.de/projects/alliance-auth-"
@@ -38,7 +38,7 @@ msgstr "Часовий пояс"
 #: admin.py:35
 #, fuzzy
 #| msgid "Selected timezone"
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr "Обраний часовий пояс"
 
 #: admin.py:59
@@ -58,6 +58,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
+
+#: admin.py:75
+#, fuzzy
+#| msgid "Selected timezone"
+msgid "Deactivate selected timezones"
+msgstr "Обраний часовий пояс"
 
 #: admin.py:99
 #, python-brace-format

--- a/timezones/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/timezones/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-27 12:24+0200\n"
+"POT-Creation-Date: 2023-09-27 15:42+0200\n"
 "PO-Revision-Date: 2023-09-24 13:13+0000\n"
 "Last-Translator: Peter Pfeufer <info@ppfeufer.de>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.ppfeufer.de/projects/"
@@ -32,7 +32,7 @@ msgid "Time zone"
 msgstr ""
 
 #: admin.py:35
-msgid "Activate selected timezone(s)"
+msgid "Activate selected timezones"
 msgstr ""
 
 #: admin.py:59
@@ -46,6 +46,10 @@ msgstr[0] ""
 msgid "Activated {notifications_count} timezone"
 msgid_plural "Activated {notifications_count} timezones"
 msgstr[0] ""
+
+#: admin.py:75
+msgid "Deactivate selected timezones"
+msgstr ""
 
 #: admin.py:99
 #, python-brace-format


### PR DESCRIPTION
## Description

### Fixed

- Translatable strings in dropdown in admin backend

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
