### PR TITLE
[FIX] Translation string escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Section Order:
 
 ### Fixed
 
+- Escaping translation strings to fix potential issues with French and Italian translations
 - JS variable declaration in the template. (`const` instead of `let`)
 
 ## [2.2.2] - 2024-12-14

--- a/timezones/locale/django.pot
+++ b/timezones/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Timezones 2.2.1\n"
+"Project-Id-Version: AA Timezones 2.2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-timezones/issues\n"
-"POT-Creation-Date: 2024-12-14 19:10+0100\n"
+"POT-Creation-Date: 2025-01-13 15:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,13 +125,13 @@ msgstr ""
 msgid "Eve time"
 msgstr ""
 
-#: timezones/templates/timezones/index.html:73
-#: timezones/templates/timezones/partials/timezones/adjust-time.html:41
-msgid "Days"
+#: timezones/templates/timezones/index.html:68
+msgid "Already over, you missed it!"
 msgstr ""
 
-#: timezones/templates/timezones/index.html:74
-msgid "Already over, you missed it!"
+#: timezones/templates/timezones/index.html:75
+#: timezones/templates/timezones/partials/timezones/adjust-time.html:41
+msgid "Days"
 msgstr ""
 
 #: timezones/templates/timezones/partials/footer/app-translation-footer.html:5

--- a/timezones/templates/timezones/index.html
+++ b/timezones/templates/timezones/index.html
@@ -65,13 +65,15 @@
     {% include 'timezones/partials/timezones/adjust-time.html' %}
 
     <!-- share options with JS part -->
+    {% translate "Already over, you missed it!" as alreadyOver %}
+
     <script>
         const aaTimezonesOptions = {
             base_url: '{% url "timezones:index" %}',
             timestamp: '{{ timestamp }}',
             translation: {
                 days: '{% translate "Days" %}',
-                alreadyOver: '{% translate "Already over, you missed it!" %}'
+                alreadyOver: '{{ alreadyOver|escapejs }}'
             }
         }
     </script>


### PR DESCRIPTION
## Description

### Fixed

- Escaping translation strings to fix potential issues with French and Italian translations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
