### PR TITLE
[CHANGE] Use `text-bg-*` instead of `bg-*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Use `text-bg-*` instead of `bg-*` to make use of Bootstraps native color contrast detection
+
 ## [2.3.3] - 2025-04-09
 
 ### Fixed

--- a/timezones/templates/timezones/index.html
+++ b/timezones/templates/timezones/index.html
@@ -7,7 +7,7 @@
         <!-- // Local Time -->
         <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
             <div class="card border-warning">
-                <div class="card-header bg-warning">
+                <div class="card-header text-bg-warning">
                     <div class="card-title text-white mb-0">
                         {% translate "Local time" %}
                         <span class="float-end">
@@ -27,7 +27,7 @@
         <!-- // EVE time -->
         <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
             <div class="card border-success">
-                <div class="card-header bg-success">
+                <div class="card-header text-bg-success">
                     <div class="card-title text-white mb-0">
                         {% translate "EVE time" %}
                         <span class="float-end">

--- a/timezones/templates/timezones/partials/timezones/timezone-panel.html
+++ b/timezones/templates/timezones/partials/timezones/timezone-panel.html
@@ -2,7 +2,7 @@
 
 <div class="col-sm-6 col-md-4 col-lg-3">
     <div class="card border-{{ timezone.panelType|default:'default' }} mb-4">
-        <div class="card-header bg-{{ timezone.panelType|default:'default' }}">
+        <div class="card-header text-bg-{{ timezone.panelType|default:'default' }}">
             <div class="card-title mb-0">
                 {{ timezone.panel_name }}
                 <span class="float-end">


### PR DESCRIPTION
## Description

### Changed

- Use `text-bg-*` instead of `bg-*` to make use of Bootstraps native color contrast detection

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
