### PR TITLE
[RELEASE] v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.4.0] - 2025-06-03
+
 ### Changed
 
 - Weather Icons CSS updated to v2.0.10 (properly this time)

--- a/timezones/__init__.py
+++ b/timezones/__init__.py
@@ -5,5 +5,5 @@ Application init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.3.4"
+__version__ = "2.4.0"
 __title__ = _("Time Zones")

--- a/timezones/locale/django.pot
+++ b/timezones/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Timezones 2.3.4\n"
+"Project-Id-Version: AA Timezones 2.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-timezones/issues\n"
-"POT-Creation-Date: 2025-05-06 01:13+0200\n"
+"POT-Creation-Date: 2025-06-03 14:24+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,6 @@ msgstr ""
 
 #: timezones/__init__.py:9 timezones/templates/timezones/base.html:6
 #: timezones/templates/timezones/base.html:10
-#: timezones/templates/timezones/base.html:17
 msgid "Time Zones"
 msgstr ""
 


### PR DESCRIPTION
## [2.4.0] - 2025-06-03

### Changed

- Weather Icons CSS updated to v2.0.10 (properly this time)

### Removed

- Redundant header from public views
- Cache breaker for static files. Doesn't work as expected with `django-sri`.