### PR TITLE
[FIX] Deprecated `utcnow` usage in favor of `now` with timezone argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Fixed
+
+- Deprecated `utcnow` usage in favor of `now` with timezone argument
+
 ### Changed
 
 - Switch to Terser for JavaScript compression

--- a/timezones/aadiscordbot/cogs/time.py
+++ b/timezones/aadiscordbot/cogs/time.py
@@ -4,7 +4,7 @@ https://github.com/pvyParts/allianceauth-discordbot
 """
 
 # Standard Library
-from datetime import datetime
+import datetime as dt
 
 # Third Party
 import pytz
@@ -76,7 +76,7 @@ class Time(commands.Cog):
 
         fmt_utc = "%H:%M:%S (UTC)\n%A %d. %b %Y"
         fmt = "%H:%M:%S (UTC %z)\n%A %d. %b %Y"
-        utc_now = datetime.utcnow()
+        utc_now = dt.datetime.now(dt.timezone.utc)
         utc_timestamp = utc_now.strftime("%s")
 
         embed = Embed(title="Time")
@@ -124,7 +124,7 @@ class Time(commands.Cog):
                 embed.add_field(
                     name=configured_timezone["panel_name"],
                     value=(
-                        datetime.utcnow()
+                        dt.datetime.now(dt.timezone.utc)
                         .astimezone(
                             pytz.timezone(
                                 configured_timezone["timezone"]["timezone_name"]


### PR DESCRIPTION
## Description

### Fixed

- Deprecated `utcnow` usage in favor of `now` with timezone argument

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
