### PR TITLE
[RELEASE] v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [2.4.2] - 2025-10-07
+
 ### Fixed
 
 - Deprecated `utcnow` usage in favor of `now` with timezone argument
@@ -691,7 +693,8 @@ Section Order:
 [2.3.4]: https://github.com/ppfeufer/aa-timezones/compare/v2.3.3...v2.3.4 "v2.3.4"
 [2.4.0]: https://github.com/ppfeufer/aa-timezones/compare/v2.3.4...v2.4.0 "v2.4.0"
 [2.4.1]: https://github.com/ppfeufer/aa-timezones/compare/v2.4.0...v2.4.1 "v2.4.1"
-[in development]: https://github.com/ppfeufer/aa-timezones/compare/v2.4.1...HEAD "In Development"
+[2.4.2]: https://github.com/ppfeufer/aa-timezones/compare/v2.4.1...v2.4.2 "v2.4.2"
+[in development]: https://github.com/ppfeufer/aa-timezones/compare/v2.4.2...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [readme]: https://github.com/ppfeufer/aa-timezones/blob/master/README.md "README.md"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```bash
-pip install aa-timezones==2.4.1
+pip install aa-timezones==2.4.2
 ```
 
 ### Step 2: Update Your Alliance Auth Settings<a name="step-2-update-your-alliance-auth-settings"></a>
@@ -117,7 +117,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```bash
-pip install aa-timezones==2.4.1
+pip install aa-timezones==2.4.2
 ```
 
 ```bash

--- a/timezones/__init__.py
+++ b/timezones/__init__.py
@@ -5,5 +5,5 @@ Application init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 __title__ = _("Time Zones")


### PR DESCRIPTION
## [2.4.2] - 2025-10-07

### Fixed

- Deprecated `utcnow` usage in favor of `now` with timezone argument

### Changed

- Switch to Terser for JavaScript compression