### PR TITLE
[RELEASE] v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.1.0] - 2026-07-19
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5.2.0 or newer!**
@@ -802,7 +804,8 @@ Section Order:
 [2.6.2]: https://github.com/ppfeufer/aa-timezones/compare/v2.6.1...v2.6.2 "v2.6.2"
 [3.0.0]: https://github.com/ppfeufer/aa-timezones/compare/v2.6.2...v3.0.0 "v3.0.0"
 [3.0.1]: https://github.com/ppfeufer/aa-timezones/compare/v3.0.0...v3.0.1 "v3.0.1"
-[in development]: https://github.com/ppfeufer/aa-timezones/compare/v3.0.1...HEAD "In Development"
+[3.1.0]: https://github.com/ppfeufer/aa-timezones/compare/v3.0.1...v3.1.0 "v3.1.0"
+[in development]: https://github.com/ppfeufer/aa-timezones/compare/v3.1.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [readme]: https://github.com/ppfeufer/aa-timezones/blob/master/README.md "README.md"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```bash
-pip install aa-timezones==3.0.1
+pip install aa-timezones==3.1.0
 ```
 
 ### Step 2: Update Your Alliance Auth Settings<a name="step-2-update-your-alliance-auth-settings"></a>
@@ -118,7 +118,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```bash
-pip install aa-timezones==3.0.1
+pip install aa-timezones==3.1.0
 ```
 
 ```bash

--- a/timezones/__init__.py
+++ b/timezones/__init__.py
@@ -5,6 +5,6 @@ Application init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 __title__ = "Time Zones"
 __title_translated__ = _("Time Zones")

--- a/timezones/locale/django.pot
+++ b/timezones/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Timezones 3.0.1\n"
+"Project-Id-Version: AA Timezones 3.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-timezones/issues\n"
-"POT-Creation-Date: 2026-07-07 11:22+0200\n"
+"POT-Creation-Date: 2026-07-19 10:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [3.1.0] - 2026-07-19

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5.2.0 or newer!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version; otherwise, an update to Alliance Auth will be pulled in unsupervised.

### Changed

- `moment-timezone.js` library updated to v0.6.3
- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`